### PR TITLE
normalize signature content type in mdn

### DIFF
--- a/lib/as2/config.rb
+++ b/lib/as2/config.rb
@@ -12,7 +12,9 @@ module As2
       end
     end
 
-    class Partner < Struct.new :name, :url, :certificate
+    # @param [Bool] server_mdn_normalize_x_pkcs7_signature Should we transform 'application/x-pkcs7-signature' to 'application/pkcs7-signature'
+    #   when building MDNs? Some partners don't understand 'application/x-pkcs7-signature'.
+    class Partner < Struct.new :name, :url, :certificate, :server_mdn_normalize_x_pkcs7_signature
       def url=(url)
         if url.kind_of? String
           self['url'] = URI.parse url

--- a/lib/as2/server.rb
+++ b/lib/as2/server.rb
@@ -104,6 +104,13 @@ module As2
       content_type = smime_signed[/^Content-Type: (.+?)$/m, 1]
       # smime_signed.sub!(/\A.+?^(?=---)/m, '')
 
+      # some partners don't understand.
+      # i think newer openssl will use just pkcs7-signature.
+      if @partner.server_mdn_normalize_x_pkcs7_signature
+        content_type.sub!('x-pkcs7-signature', 'pkcs7-signature')
+        smime_signed.gsub!('x-pkcs7-signature', 'pkcs7-signature')
+      end
+
       headers = {}
       headers['Content-Type'] = content_type
       # TODO: if MIME-Version header is actually needed, should extract it out of smime_signed.

--- a/lib/as2/server.rb
+++ b/lib/as2/server.rb
@@ -106,7 +106,7 @@ module As2
 
       # some partners don't understand.
       # i think newer openssl will use just pkcs7-signature.
-      if @partner.server_mdn_normalize_x_pkcs7_signature
+      if @partner&.server_mdn_normalize_x_pkcs7_signature
         content_type.sub!('x-pkcs7-signature', 'pkcs7-signature')
         smime_signed.gsub!('x-pkcs7-signature', 'pkcs7-signature')
       end

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -35,6 +35,17 @@ describe As2::Config do
         assert_equal @partner_config.certificate, cert_instance
       end
     end
+
+    describe '#server_mdn_normalize_x_pkcs7_signature' do
+      it 'is nil by default' do
+        assert_nil @partner_config.server_mdn_normalize_x_pkcs7_signature
+      end
+
+      it 'can be configured' do
+        @partner_config.server_mdn_normalize_x_pkcs7_signature = true
+        assert @partner_config.server_mdn_normalize_x_pkcs7_signature
+      end
+    end
   end
 
   describe 'ServerInfo' do

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -98,5 +98,34 @@ describe As2::Server do
       assert_equal expected_plain_text.strip, plain_text.body.to_s.strip
       assert_equal expected_notification.strip, notification.body.to_s.strip
     end
+
+    describe 'mdn_normalize_x_pkcs7_signature option' do
+      it 'leaves the x- by default' do
+        env = {
+          'HTTP_MESSAGE_ID' => '<message@server>',
+          'HTTP_AS2_FROM' => 'ALICE'
+        }
+        status, headers, body = @server.send_mdn(env, 'micmicmic', 'sha256')
+
+        assert headers['Content-Type']['application/x-pkcs7-signature']
+        assert body[0]['Content-Type: application/x-pkcs7-signature']
+        assert_nil body[0]['Content-Type: application/pkcs7-signature']
+      end
+
+      it 'removes the x- if requested' do
+        @partner.server_mdn_normalize_x_pkcs7_signature = true
+        @server = As2::Server.new(server_info: @server_info, partner: @partner)
+
+        env = {
+          'HTTP_MESSAGE_ID' => '<message@server>',
+          'HTTP_AS2_FROM' => 'ALICE'
+        }
+        status, headers, body = @server.send_mdn(env, 'micmicmic', 'sha256')
+
+        assert headers['Content-Type']['application/pkcs7-signature']
+        assert body[0]['Content-Type: application/pkcs7-signature']
+        assert_nil body[0]['Content-Type: application/x-pkcs7-signature']
+      end
+    end
   end
 end


### PR DESCRIPTION
when building MDN responses, allow us to change `application/x-pkcs7-signature` to `application/pkcs7-signature` if needed for a particular partner.