### PR TITLE
Message enhancements

### DIFF
--- a/lib/as2/digest_selector.rb
+++ b/lib/as2/digest_selector.rb
@@ -10,15 +10,31 @@ module As2
       'md5' => OpenSSL::Digest::MD5
     }
 
+    # @return [Array] all the codes we understand
     def self.valid_codes
       @map.keys
     end
 
-    def self.for_code(code)
-      # we may receive 'sha256', 'sha-256', or 'SHA256'.
-      normalized = code.strip.downcase.gsub(/[^a-z0-9]/, '')
+    # @param [String] code an algorithm identifier like 'sha256' or 'md5'
+    # @return [boolean] do we recognize this code?
+    def self.valid_code?(code)
+      normalized = normalize(code)
+      valid_codes.include?(normalized)
+    end
 
+    # @param [String] code an algorithm identifier like 'sha256' or 'md5'
+    # @return [Class] an OpenSSL::Digest class implementing the requested algorithm
+    #   returns OpenSSL::Digest::SHA1 if the requested code is not recognized
+    def self.for_code(code)
+      normalized = normalize(code)
       @map[normalized] || OpenSSL::Digest::SHA1
+    end
+
+    private
+
+    def self.normalize(code)
+      # we may receive 'sha256', 'sha-256', or 'SHA256'.
+      code.strip.downcase.gsub(/[^a-z0-9]/, '')
     end
   end
 end

--- a/test/digest_selector_test.rb
+++ b/test/digest_selector_test.rb
@@ -1,6 +1,20 @@
 require 'test_helper'
 
 describe As2::DigestSelector do
+  describe '.valid_codes' do
+    it 'returns an array of recognized codes' do
+      assert_equal Array, As2::DigestSelector.valid_codes.class
+    end
+  end
+
+  describe '.valid_code?' do
+    it 'indicates if the given code is understood' do
+      assert As2::DigestSelector.valid_code?('sha256')
+      assert As2::DigestSelector.valid_code?('sha-256')
+      assert !As2::DigestSelector.valid_code?('sha-1000')
+    end
+  end
+
   describe '.for_code' do
     it 'can build a base64digest for all supported algorithm codes' do
       As2::DigestSelector.valid_codes.each do |code|

--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -212,7 +212,7 @@ describe As2::Message do
       assert_equal attachment.class, Mail::Part
       assert_equal attachment.content_type, 'application/octet-stream'
       assert_equal correct_cleartext, attachment.body.to_s
-      assert_equal nil, attachment.filename
+      assert_nil attachment.filename
     end
   end
 end


### PR DESCRIPTION
improvements to `As2::Message`. Unsure if these will be released or not. Saving here for visibility.

  1. allow caller to specify how message content is encoded. alternative: try both and use begin/rescue to detect if the first attempt fails.
  2. allow caller to specify which algorithm to use for MIC generation. this would be extracted from HTTP Disposition-Notification-Options header.