### PR TITLE
WIP: try to address warnings about constant redefinitions

### DIFF
--- a/lib/as2.rb
+++ b/lib/as2.rb
@@ -1,5 +1,3 @@
-require 'openssl'
-require 'mail'
 require 'securerandom'
 require 'as2/config'
 require 'as2/server'

--- a/lib/as2/client.rb
+++ b/lib/as2/client.rb
@@ -1,4 +1,6 @@
+require 'mail'
 require 'net/http'
+require 'openssl'
 
 module As2
   class Client

--- a/lib/as2/config.rb
+++ b/lib/as2/config.rb
@@ -1,4 +1,6 @@
+require 'openssl'
 require 'uri'
+
 module As2
   module Config
     def self.build_certificate(input)

--- a/lib/as2/server.rb
+++ b/lib/as2/server.rb
@@ -1,6 +1,8 @@
-require 'rack'
 require 'logger'
+require 'openssl'
+require 'rack'
 require 'stringio'
+
 require 'as2/mime_generator'
 require 'as2/message'
 


### PR DESCRIPTION
example:

```
  $ bundle exec rake test
  ... snip ...
  /Users/alexdean/.rvm/rubies/ruby-2.6.4/lib/ruby/2.6.0/net/protocol.rb:30: warning: method redefined; discarding old protocol_param
  /Users/alexdean/.rvm/gems/ruby-2.6.4/gems/net-protocol-0.2.1/lib/net/protocol.rb:32: warning: previous definition of protocol_param was here
  /Users/alexdean/.rvm/rubies/ruby-2.6.4/lib/ruby/2.6.0/net/protocol.rb:38: warning: method redefined; discarding old ssl_socket_connect
  /Users/alexdean/.rvm/gems/ruby-2.6.4/gems/net-protocol-0.2.1/lib/net/protocol.rb:40: warning: previous definition of ssl_socket_connect was here
  /Users/alexdean/.rvm/rubies/ruby-2.6.4/lib/ruby/2.6.0/net/protocol.rb:66: warning: already initialized constant Net::ProtocRetryError
  /Users/alexdean/.rvm/gems/ruby-2.6.4/gems/net-protocol-0.2.1/lib/net/protocol.rb:68: warning: previous definition of ProtocRetryError was here
  /Users/alexdean/.rvm/rubies/ruby-2.6.4/lib/ruby/2.6.0/net/protocol.rb:79: warning: method redefined; discarding old initialize
  /Users/alexdean/.rvm/gems/ruby-2.6.4/gems/net-protocol-0.2.1/lib/net/protocol.rb:81: warning: previous definition of initialize was here
  /Users/alexdean/.rvm/rubies/ruby-2.6.4/lib/ruby/2.6.0/net/protocol.rb:82: warning: method redefined; discarding old io
  /Users/alexdean/.rvm/rubies/ruby-2.6.4/lib/ruby/2.6.0/net/protocol.rb:84: warning: method redefined; discarding old message
```

changes made so far don't seem to resolve the error, so this might not be useful.

unsure, but it seems like these might be due to bug in mail and/or rubygems. https://github.com/mikel/mail/pull/1439