### PR TITLE
remove MIME headers from MDN body

### DIFF
--- a/lib/as2/server.rb
+++ b/lib/as2/server.rb
@@ -99,10 +99,15 @@ module As2
 
       pkcs7 = OpenSSL::PKCS7.sign @server_info.certificate, @server_info.pkey, msg_out.string
       pkcs7.detached = true
+
       smime_signed = OpenSSL::PKCS7.write_smime pkcs7, msg_out.string
 
       content_type = smime_signed[/^Content-Type: (.+?)$/m, 1]
-      # smime_signed.sub!(/\A.+?^(?=---)/m, '')
+
+      # strip everything before the first MIME boundary
+      # (removes MIME headers and plain text "This is an S/MIME signed message"
+      # from the message body...)
+      smime_signed.sub!(/\A.+?^(?=---)/m, '')
 
       headers = {}
       headers['Content-Type'] = content_type

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -65,6 +65,8 @@ describe As2::Server do
       }
       _status, headers, body = @server.send_mdn(env, 'micmicmic', 'sha256', 'error message')
 
+      # TODO: this fails when MIME headers are not present in body.
+      # we can instead extract them from the HTTP Content-Type header.
       response = OpenSSL::PKCS7.read_smime body.first.strip
       assert_equal @server_info.certificate.serial, response.signers.first.serial
 


### PR DESCRIPTION
we copy this info into the HTTP Content-Type header, so it may be unneeded in the message body. this is an experiment to see if this helps some partners parse our MDNs correct.

example HTTP header we construct (from our test suite): "Content-Type"=>"multipart/signed; protocol=\"application/x-pkcs7-signature\"; micalg=\"sha-256\"; boundary=\"----EA844AF3EF6602166CC79DFB25ECBB6F\""

have confirmed an MDN built this way can be successfully processed by Mendelson server.