### PR TITLE
remove MIME headers from MDN body - take 2

### DIFF
--- a/lib/as2/server.rb
+++ b/lib/as2/server.rb
@@ -99,10 +99,15 @@ module As2
 
       pkcs7 = OpenSSL::PKCS7.sign @server_info.certificate, @server_info.pkey, msg_out.string
       pkcs7.detached = true
+
       smime_signed = OpenSSL::PKCS7.write_smime pkcs7, msg_out.string
 
       content_type = smime_signed[/^Content-Type: (.+?)$/m, 1]
-      # smime_signed.sub!(/\A.+?^(?=---)/m, '')
+
+      # strip everything before the first MIME boundary
+      # (removes MIME headers and plain text "This is an S/MIME signed message"
+      # from the message body...)
+      smime_signed.sub!(/\A.+?^(?=---)/m, '')
 
       headers = {}
       headers['Content-Type'] = content_type

--- a/lib/as2/server.rb
+++ b/lib/as2/server.rb
@@ -104,10 +104,12 @@ module As2
 
       content_type = smime_signed[/^Content-Type: (.+?)$/m, 1]
 
-      # strip everything before the first MIME boundary
-      # (removes MIME headers and plain text "This is an S/MIME signed message"
-      # from the message body...)
+      # strip everything before the first MIME boundary from the message body
+      # (removes MIME headers and plain text "This is an S/MIME signed message")
       smime_signed.sub!(/\A.+?^(?=---)/m, '')
+
+      # replace any bare "\n" (not preceeded by "\r") with "\r\n"
+      smime_signed.gsub!(/(?<!\r)\n/, "\r\n")
 
       headers = {}
       headers['Content-Type'] = content_type

--- a/lib/as2/server.rb
+++ b/lib/as2/server.rb
@@ -109,6 +109,9 @@ module As2
       smime_signed.sub!(/\A.+?^(?=---)/m, '')
 
       # replace any bare "\n" (not preceeded by "\r") with "\r\n"
+      # risk: if any `report` lines do not end with \r\n, this global gsub will
+      # invalidate the signature. MimeGenerator currently always adds \r\n line endings,
+      # but should probably find a smarter/more-selective way to do this.
       smime_signed.gsub!(/(?<!\r)\n/, "\r\n")
 
       headers = {}

--- a/lib/as2/server.rb
+++ b/lib/as2/server.rb
@@ -111,14 +111,14 @@ module As2
       body = boundary + "\r\n"
       # this is the MDN report, with text/plain and message/disposition-notification parts
       body += msg_out.string
-      body += boundary + "\r\n"
+      body += boundary + "\r\n\r\n"
       # this is the signature generated over that report
       body += "Content-Type: application/pkcs7-signature; name=\"smime.p7s\"\r\n"
       body += "Content-Transfer-Encoding: base64\r\n"
       body += "Content-Disposition: attachment; filename=\"smime.p7s\"\r\n"
       body += "\r\n"
       body += bare_pem_signature
-      body += boundary + "--\r\n"
+      body += boundary + "--\r\n\r\n"
 
       headers = {}
       headers['Content-Type'] = "multipart/signed; protocol=\"application/pkcs7-signature\"; micalg=\"#{mic_algorithm}\"; boundary=\"#{boundary}\""

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -30,7 +30,10 @@ describe As2::Server do
       }
       _status, headers, body = @server.send_mdn(env, 'micmicmic', 'sha256')
 
-      response = OpenSSL::PKCS7.read_smime body.first.strip
+      # read_smime needs Content-Type from HTTP headers.
+      payload = "Content-Type: #{headers['Content-Type']}\r\n\r\n#{body.first.strip}"
+
+      response = OpenSSL::PKCS7.read_smime(payload)
       assert_equal @server_info.certificate.serial, response.signers.first.serial
 
       response.verify [@server_info.certificate], OpenSSL::X509::Store.new, nil, OpenSSL::PKCS7::NOVERIFY | OpenSSL::PKCS7::NOINTERN
@@ -65,9 +68,9 @@ describe As2::Server do
       }
       _status, headers, body = @server.send_mdn(env, 'micmicmic', 'sha256', 'error message')
 
-      # TODO: this fails when MIME headers are not present in body.
-      # we can instead extract them from the HTTP Content-Type header.
-      response = OpenSSL::PKCS7.read_smime body.first.strip
+      # read_smime needs Content-Type from HTTP headers.
+      payload = "Content-Type: #{headers['Content-Type']}\r\n\r\n#{body.first.strip}"
+      response = OpenSSL::PKCS7.read_smime payload
       assert_equal @server_info.certificate.serial, response.signers.first.serial
 
       response.verify [@server_info.certificate], OpenSSL::X509::Store.new, nil, OpenSSL::PKCS7::NOVERIFY | OpenSSL::PKCS7::NOINTERN

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -65,6 +65,8 @@ describe As2::Server do
       }
       _status, headers, body = @server.send_mdn(env, 'micmicmic', 'sha256', 'error message')
 
+      # TODO: this fails when MIME headers are not present in body.
+      # we can instead extract them from the HTTP Content-Type header.
       response = OpenSSL::PKCS7.read_smime body.first.strip
       assert_equal @server_info.certificate.serial, response.signers.first.serial
 


### PR DESCRIPTION
we copy this info into the HTTP Content-Type header, so it may be unneeded in the message body. this is an experiment to see if this helps some partners parse our MDNs correct.

example HTTP header we construct (from our test suite): "Content-Type"=>"multipart/signed; protocol=\"application/x-pkcs7-signature\"; micalg=\"sha-256\"; boundary=\"----EA844AF3EF6602166CC79DFB25ECBB6F\""