### PR TITLE
quote AS2-To / AS2-From identifiers which contain spaces

### DIFF
--- a/lib/as2.rb
+++ b/lib/as2.rb
@@ -35,4 +35,13 @@ module As2
     parsed = As2::Parser::DispositionNotificationOptions.parse(disposition_notification_options)
     Array(parsed['signed-receipt-micalg']).find { |m| As2::DigestSelector.valid?(m) }
   end
+
+  # surround an As2-From/As2-To value with double-quotes, if it contains a space.
+  def self.quoted_system_identifier(name)
+    if name.to_s.include?(' ')
+      "\"#{name}\""
+    else
+      name
+    end
+  end
 end

--- a/lib/as2/client.rb
+++ b/lib/as2/client.rb
@@ -56,8 +56,8 @@ module As2
 
       req = Net::HTTP::Post.new @partner.url.path
       req['AS2-Version'] = '1.0' # 1.1 includes compression support, which we dont implement.
-      req['AS2-From'] = as2_from
-      req['AS2-To'] = as2_to
+      req['AS2-From'] = As2.quoted_system_identifier(as2_from)
+      req['AS2-To'] = As2.quoted_system_identifier(as2_to)
       req['Subject'] = 'AS2 Transaction'
       req['Content-Type'] = 'application/pkcs7-mime; smime-type=enveloped-data; name=smime.p7m'
       req['Date'] = Time.now.rfc2822

--- a/lib/as2/client.rb
+++ b/lib/as2/client.rb
@@ -99,9 +99,16 @@ module As2
         # note: to pass this traffic through a debugging proxy (like Charles)
         # set ENV['http_proxy'].
         http = Net::HTTP.new(@partner.url.host, @partner.url.port)
-        http.use_ssl = @partner.url.scheme == 'https'
+
+        use_ssl = @partner.url.scheme == 'https'
+        http.use_ssl = use_ssl
+        if use_ssl
+          if @partner.tls_verify_mode
+            http.verify_mode = @partner.tls_verify_mode
+          end
+        end
+
         # http.set_debug_output $stderr
-        # http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
         http.start do
           resp = http.request(req)
@@ -120,6 +127,7 @@ module As2
       end
 
       Result.new(
+        request: req,
         response: resp,
         mic_matched: mdn_report[:mic_matched],
         mid_matched: mdn_report[:mid_matched],

--- a/lib/as2/client/result.rb
+++ b/lib/as2/client/result.rb
@@ -1,9 +1,10 @@
 module As2
   class Client
     class Result
-      attr_reader :response, :mic_matched, :mid_matched, :body, :disposition, :signature_verification_error, :exception, :outbound_message_id
+      attr_reader :request, :response, :mic_matched, :mid_matched, :body, :disposition, :signature_verification_error, :exception, :outbound_message_id
 
-      def initialize(response:, mic_matched:, mid_matched:, body:, disposition:, signature_verification_error:, exception:, outbound_message_id:)
+      def initialize(request:, response:, mic_matched:, mid_matched:, body:, disposition:, signature_verification_error:, exception:, outbound_message_id:)
+        @request = request
         @response = response
         @mic_matched = mic_matched
         @mid_matched = mid_matched

--- a/lib/as2/config.rb
+++ b/lib/as2/config.rb
@@ -12,7 +12,7 @@ module As2
       end
     end
 
-    class Partner < Struct.new :name, :url, :certificate, :mdn_format, :outbound_format
+    class Partner < Struct.new :name, :url, :certificate, :tls_verify_mode, :mdn_format, :outbound_format
       def url=(url)
         if url.kind_of? String
           self['url'] = URI.parse url
@@ -41,6 +41,17 @@ module As2
 
       def certificate=(certificate)
         self['certificate'] = As2::Config.build_certificate(certificate)
+      end
+
+      # if set, will be used for SSL transmissions.
+      # @see `verify_mode` in https://ruby-doc.org/stdlib-2.7.1/libdoc/net/http/rdoc/Net/HTTP.html
+      def tls_verify_mode=(mode)
+        valid_modes = [nil, OpenSSL::SSL::VERIFY_NONE, OpenSSL::SSL::VERIFY_PEER]
+        if !valid_modes.include?(mode)
+          raise ArgumentError, "tls_verify_mode '#{mode}' must be one of #{valid_modes.inspect}"
+        end
+
+        self['tls_verify_mode'] = mode
       end
     end
 

--- a/lib/as2/server.rb
+++ b/lib/as2/server.rb
@@ -69,8 +69,8 @@ module As2
 
       options = {
         'Reporting-UA' => @server_info.name,
-        'Original-Recipient' => "rfc822; #{@server_info.name}",
-        'Final-Recipient' => "rfc822; #{@server_info.name}",
+        'Original-Recipient' => "rfc822; #{As2.quoted_system_identifier(@server_info.name)}",
+        'Final-Recipient' => "rfc822; #{As2.quoted_system_identifier(@server_info.name)}",
         'Original-Message-ID' => env['HTTP_MESSAGE_ID']
       }
       if failed
@@ -148,8 +148,8 @@ module As2
       # TODO: if MIME-Version header is actually needed, should extract it out of smime_signed.
       headers['MIME-Version'] = '1.0'
       headers['Message-ID'] = As2.generate_message_id(@server_info)
-      headers['AS2-From'] = @server_info.name
-      headers['AS2-To'] = as2_to
+      headers['AS2-From'] = As2.quoted_system_identifier(@server_info.name)
+      headers['AS2-To'] = As2.quoted_system_identifier(as2_to)
       headers['AS2-Version'] = '1.0'
       headers['Connection'] = 'close'
 
@@ -191,8 +191,8 @@ module As2
       headers['Content-Type'] = "multipart/signed; protocol=\"application/pkcs7-signature\"; micalg=\"#{micalg}\"; boundary=\"#{boundary}\""
       headers['MIME-Version'] = '1.0'
       headers['Message-ID'] = As2.generate_message_id(@server_info)
-      headers['AS2-From'] = @server_info.name
-      headers['AS2-To'] = as2_to
+      headers['AS2-From'] = As2.quoted_system_identifier(@server_info.name)
+      headers['AS2-To'] = As2.quoted_system_identifier(as2_to)
       headers['AS2-Version'] = '1.0'
       headers['Connection'] = 'close'
 

--- a/test/as2_test.rb
+++ b/test/as2_test.rb
@@ -40,4 +40,22 @@ describe As2 do
       assert_equal 'md5', As2.choose_mic_algorithm(header_value)
     end
   end
+
+  describe '.quoted_system_identifier' do
+    it 'returns the string unchanged if it does not contain a space' do
+      assert_equal 'A', As2.quoted_system_identifier('A')
+    end
+
+    it 'surrounds name with double-quotes if it contains a space' do
+      assert_equal '"A A"', As2.quoted_system_identifier('A A')
+    end
+
+    it 'returns non-string inputs unchanged' do
+      assert_nil As2.quoted_system_identifier(nil)
+      assert_equal 1, As2.quoted_system_identifier(1)
+      assert_equal true, As2.quoted_system_identifier(true)
+      assert_equal :symbol, As2.quoted_system_identifier(:symbol)
+      assert_equal({}, As2.quoted_system_identifier({}))
+    end
+  end
 end

--- a/test/client/result_test.rb
+++ b/test/client/result_test.rb
@@ -7,6 +7,7 @@ describe As2::Client::Result do
       signature_verification_error: nil,
       mic_matched: true,
       mid_matched: true,
+      request: nil,
       response: nil,
       body: nil,
       exception: nil,

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -52,6 +52,27 @@ describe As2::Config do
         assert_equal "outbound_format 'invalid' must be one of [\"v0\", \"v1\"]", error.message
       end
     end
+
+    describe '#tls_verify_mode=' do
+      it 'accepts an OpenSSL::SSL::VERIFY_* constant' do
+        @partner_config.tls_verify_mode = OpenSSL::SSL::VERIFY_PEER
+        assert_equal OpenSSL::SSL::VERIFY_PEER, @partner_config.tls_verify_mode
+
+        @partner_config.tls_verify_mode = OpenSSL::SSL::VERIFY_NONE
+        assert_equal OpenSSL::SSL::VERIFY_NONE, @partner_config.tls_verify_mode
+      end
+
+      it 'accepts nil' do
+        @partner_config.tls_verify_mode = nil
+        assert_nil @partner_config.tls_verify_mode
+      end
+
+      it 'raises if given an invalid value' do
+        assert_raises(ArgumentError) do
+          @partner_config.tls_verify_mode = 'invalid'
+        end
+      end
+    end
   end
 
   describe 'ServerInfo' do


### PR DESCRIPTION
per recommendation from Drummond. not sure if this is specifically mentioned in RFCs, but appears to be a consensus decision amongst AS2 implementers.