### PR TITLE
Testing enhancements

### DIFF
--- a/lib/as2/client.rb
+++ b/lib/as2/client.rb
@@ -99,9 +99,16 @@ module As2
         # note: to pass this traffic through a debugging proxy (like Charles)
         # set ENV['http_proxy'].
         http = Net::HTTP.new(@partner.url.host, @partner.url.port)
-        http.use_ssl = @partner.url.scheme == 'https'
+
+        use_ssl = @partner.url.scheme == 'https'
+        http.use_ssl = use_ssl
+        if use_ssl
+          if @partner.tls_verify_mode
+            http.verify_mode = @partner.tls_verify_mode
+          end
+        end
+
         # http.set_debug_output $stderr
-        # http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
         http.start do
           resp = http.request(req)

--- a/lib/as2/client.rb
+++ b/lib/as2/client.rb
@@ -127,6 +127,7 @@ module As2
       end
 
       Result.new(
+        request: req,
         response: resp,
         mic_matched: mdn_report[:mic_matched],
         mid_matched: mdn_report[:mid_matched],

--- a/lib/as2/client/result.rb
+++ b/lib/as2/client/result.rb
@@ -1,9 +1,10 @@
 module As2
   class Client
     class Result
-      attr_reader :response, :mic_matched, :mid_matched, :body, :disposition, :signature_verification_error, :exception, :outbound_message_id
+      attr_reader :request, :response, :mic_matched, :mid_matched, :body, :disposition, :signature_verification_error, :exception, :outbound_message_id
 
-      def initialize(response:, mic_matched:, mid_matched:, body:, disposition:, signature_verification_error:, exception:, outbound_message_id:)
+      def initialize(request:, response:, mic_matched:, mid_matched:, body:, disposition:, signature_verification_error:, exception:, outbound_message_id:)
+        @request = request
         @response = response
         @mic_matched = mic_matched
         @mid_matched = mid_matched

--- a/lib/as2/config.rb
+++ b/lib/as2/config.rb
@@ -12,7 +12,7 @@ module As2
       end
     end
 
-    class Partner < Struct.new :name, :url, :certificate, :mdn_format, :outbound_format
+    class Partner < Struct.new :name, :url, :certificate, :tls_verify_mode, :mdn_format, :outbound_format
       def url=(url)
         if url.kind_of? String
           self['url'] = URI.parse url
@@ -41,6 +41,17 @@ module As2
 
       def certificate=(certificate)
         self['certificate'] = As2::Config.build_certificate(certificate)
+      end
+
+      # if set, will be used for SSL transmissions.
+      # @see `verify_mode` in https://ruby-doc.org/stdlib-2.7.1/libdoc/net/http/rdoc/Net/HTTP.html
+      def tls_verify_mode=(mode)
+        valid_modes = [nil, OpenSSL::SSL::VERIFY_NONE, OpenSSL::SSL::VERIFY_PEER]
+        if !valid_modes.include?(mode)
+          raise ArgumentError, "tls_verify_mode '#{mode}' must be one of #{valid_modes.inspect}"
+        end
+
+        self['tls_verify_mode'] = mode
       end
     end
 

--- a/test/client/result_test.rb
+++ b/test/client/result_test.rb
@@ -7,6 +7,7 @@ describe As2::Client::Result do
       signature_verification_error: nil,
       mic_matched: true,
       mid_matched: true,
+      request: nil,
       response: nil,
       body: nil,
       exception: nil,

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -52,6 +52,27 @@ describe As2::Config do
         assert_equal "outbound_format 'invalid' must be one of [\"v0\", \"v1\"]", error.message
       end
     end
+
+    describe '#tls_verify_mode=' do
+      it 'accepts an OpenSSL::SSL::VERIFY_* constant' do
+        @partner_config.tls_verify_mode = OpenSSL::SSL::VERIFY_PEER
+        assert_equal OpenSSL::SSL::VERIFY_PEER, @partner_config.tls_verify_mode
+
+        @partner_config.tls_verify_mode = OpenSSL::SSL::VERIFY_NONE
+        assert_equal OpenSSL::SSL::VERIFY_NONE, @partner_config.tls_verify_mode
+      end
+
+      it 'accepts nil' do
+        @partner_config.tls_verify_mode = nil
+        assert_nil @partner_config.tls_verify_mode
+      end
+
+      it 'raises if given an invalid value' do
+        assert_raises(ArgumentError) do
+          @partner_config.tls_verify_mode = 'invalid'
+        end
+      end
+    end
   end
 
   describe 'ServerInfo' do


### PR DESCRIPTION
a few small tweaks that make interactive testing with partners a little easier.

  1. can disable SSL/TLS certificate verification, so it's now possible to send messages to a partner who uses a self-signed SSL/TLS certificate
  2. the `Result` returned after making a transmission to a partner now includes the raw `request` object which was sent.