### PR TITLE
don't wrap identifier in quotes if it is already quoted

### DIFF
--- a/lib/as2.rb
+++ b/lib/as2.rb
@@ -38,10 +38,20 @@ module As2
 
   # surround an As2-From/As2-To value with double-quotes, if it contains a space.
   def self.quoted_system_identifier(name)
-    if name.to_s.include?(' ')
+    if name.to_s.include?(' ') && !name.to_s.start_with?('"')
       "\"#{name}\""
     else
       name
     end
+  end
+
+  # remove double-quotes from an As2-From/As2-To value, if it contains any.
+  # this is useful in client code which may not automatically strip these quotes from a header value.
+  def self.unquoted_system_identifier(name)
+    if !name.is_a?(String)
+      return name
+    end
+
+    name.delete_prefix('"').delete_suffix('"').gsub('\"', '"')
   end
 end

--- a/test/as2_test.rb
+++ b/test/as2_test.rb
@@ -57,5 +57,33 @@ describe As2 do
       assert_equal :symbol, As2.quoted_system_identifier(:symbol)
       assert_equal({}, As2.quoted_system_identifier({}))
     end
+
+    it 'does not re-quote a string which is already quoted' do
+      assert_equal '"A A"', As2.quoted_system_identifier('"A A"')
+    end
+  end
+
+  describe '.unquoted_system_identifier' do
+    it 'removes leading/trailing double-quotes if present' do
+      assert_equal 'AA', As2.unquoted_system_identifier('"AA"')
+      assert_equal 'A A', As2.unquoted_system_identifier('"A A"')
+    end
+
+    it 'does nothing to a string which do not contain leading/trailing double-quotes' do
+      assert_equal 'AA', As2.unquoted_system_identifier('AA')
+      assert_equal 'A A', As2.unquoted_system_identifier('A A')
+    end
+
+    it 'unescapes interior double-quotes' do
+      assert_equal 'A"A', As2.unquoted_system_identifier('"A\"A"')
+    end
+
+    it 'returns non-string inputs unchanged' do
+      assert_nil As2.unquoted_system_identifier(nil)
+      assert_equal 1, As2.unquoted_system_identifier(1)
+      assert_equal true, As2.unquoted_system_identifier(true)
+      assert_equal :symbol, As2.unquoted_system_identifier(:symbol)
+      assert_equal({}, As2.unquoted_system_identifier({}))
+    end
   end
 end


### PR DESCRIPTION
followup from #30. fixes an issue when we receive messages with quoted identifiers.